### PR TITLE
WIP fix: workshop updates for 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
 - Optionally [Yarn](https://yarnpkg.com/) or [Pnpm](https://pnpm.io/)
 - [GitHub](https://github.com/) account
 - IDE of your choice
-- A [Fly.io](https://fly.io/) account with CLI installed
-  - Check with: `fly help`
-  - `Note` No need to set up the Credit card, we will use free tier
 
 ### Getting the repo
 
@@ -64,16 +61,13 @@ Join the [Discord channel](https://discord.gg/xr95Aap5)
 | 📖 [Automate your workspace with local plugins and custom generators](./exercises/advanced/custom-plugins.md)                                                                  |
 | `☕ Break`                                                                                                                                                                     |
 | 📖 [Learn how to write and test your complex generators](./exercises/advanced/complex-generators.md)                                                                           |
-| 📖 [Write advanced deployment targets using a custom executor](./exercises/advanced/deploy-target-and-custom-executor.md)                                                      |
-| `☕ Break`                                                                                                                                                                     |
 | 📖 [Set up CI for your pull requests, connect to Nx Cloud, enable remote caching and the GitHub integration](./exercises/advanced/setup-ci-and-connect-nx-cloud.md)            |
-| 📖 [Nx Caching deep dive: Strategies for debugging cache misses, optimization strategies, and fine-tuning cache inputs and outputs](./exercises/advanced/caching-deep-dive.md) |
-| 📖 [Set up continuous deployment pipeline for affected applications](./exercises/advanced/continuous-deployment.md)                                                            |
 | `☕ Break`                                                                                                                                                                     |
+| 📖 [Nx Caching deep dive: Strategies for debugging cache misses, optimization strategies, and fine-tuning cache inputs and outputs](./exercises/advanced/caching-deep-dive.md) |
 | 📖 [Configure task distribution on CI with Nx Agents, including exploring custom launch templates and dynamic agent scaling.](./exercises/advanced/nx-agents.md)               |
+| `☕ Break`                                                                                                                                                                     |
 | 📖 [Leverage Nx Crystal plugins and Nx Atomizer to configure task splitting for improving CI distribution and speed](./exercises/advanced/atomizer.md)                         |
 | 📖 [Explore flaky task detection](./exercises/advanced/flaky-tasks.md)                                                                                                         |
-| `Bonus:` [Infer Fly.io deploy target](./exercises/advanced/infer-target.md)                                                                                                    |
 | `Bonus:` [Nx import, CodeOwners, and Conformance](./exercises/advanced/bonus.md)                                                                                               |
 
 ---

--- a/exercises/advanced/bonus.md
+++ b/exercises/advanced/bonus.md
@@ -7,24 +7,26 @@
 
 ## 🏋️‍♀️&nbsp;&nbsp;Steps:
 
-### 1. Use Nx import to import an existing Angular project
+### 1. Use Nx import to import an existing Vite project
 
-As a first step, create a new Angular project in some folder outside of the current workspace. Note use Angular 18 for now as Nx support is for v19 is about to drop but might not be out yet by the time of this workshop.
+As a first step, create a new project in some folder outside of the current workspace. This project does not need to use the same technology stack as what is in the existing monorepo. For this example, you could use [Vite to create a React project](https://vite.dev/guide/#scaffolding-your-first-vite-project).
 
 ```bash
-npx @angular/cli@18 new my-app
+npx create vite@latest my-vite-app --template react
 ```
 
 Then run the following command to import it into the current workspace:
 
 ```bash
-npx nx import <path-to-ng-project>
+npx nx import <path-to-vite-project>
 ```
 
-Confirm the installation of the `@nx/angular` and `@nx/jest` plugin.
-Once installed, try to serve the app. Nx is directly running the script of the `package.json` from the imported Angular app.
+Confirm the installation of the `@nx/jest` plugin. The `@nx/angular` plugin will not be needed for the Vite project.
+Once installed, try to serve the app. Nx is directly running the script of the `package.json` from the imported app.
 
-You can even completely remove all `package.json > scripts` from the imported Angular project as the `@nx/angular` Crystal plugin will automatically detect the `angular.json` and know how to run the various targets.
+You can even completely remove all `package.json > scripts` from the imported Vite project as the `@nx/vite` Crystal plugin will automatically detect the `vite.config.ts` and know how to run the various targets.
+
+Now, Nx is aware of the Vite project. It will appear in the `nx graph`, and commands that run tasks like `nx run-many -t build` will automatically run that target for the Vite project as well as the other projects in the workspace.
 
 ### 2. Activate Powerpack
 

--- a/exercises/advanced/caching-deep-dive.md
+++ b/exercises/advanced/caching-deep-dive.md
@@ -113,4 +113,4 @@ For the time being, it's important to be aware of this behavior.
 
 In this lab we learned how to optimize our task inputs to get the best caching results. In the next lab we will use some of those learnings to implement the continuous deployment in the most optimal way.
 
-## [➡️ Next lab ➡️](./continuous-deployment.md)
+## [➡️ Next lab ➡️](./nx-agents.md)

--- a/exercises/advanced/complex-generators.md
+++ b/exercises/advanced/complex-generators.md
@@ -234,7 +234,7 @@ Create a test to automate verification of this generator in `libs/internal-plugi
 ```typescript
 import { readJson, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { libraryGenerator } from '@nx/js/generators';
+import { libraryGenerator } from '@nx/js';
 import { generatorGenerator, pluginGenerator } from '@nx/plugin/generators';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -248,8 +248,16 @@ describe('update-scope-schema generator', () => {
   beforeEach(async () => {
     appTree = createTreeWithEmptyWorkspace();
     await addUtilLibProject(appTree);
-    await libraryGenerator(appTree, { name: 'foo', tags: 'scope:foo' });
-    await libraryGenerator(appTree, { name: 'bar', tags: 'scope:bar' });
+    await libraryGenerator(appTree, {
+      name: 'foo',
+      tags: 'scope:foo',
+      directory: 'foo',
+    });
+    await libraryGenerator(appTree, {
+      name: 'bar',
+      tags: 'scope:bar',
+      directory: 'bar',
+    });
   });
 
   it('should adjust the util-lib generator based on existing projects', async () => {
@@ -272,7 +280,7 @@ describe('update-scope-schema generator', () => {
       'libs/internal-plugin/src/generators/util-lib/schema.d.ts',
       'utf-8'
     );
-    expect(schemaInterface).toContain(`export interface Schema {
+    expect(schemaInterface).toContain(`export interface UtilLibGeneratorSchema {
   name: string;
   directory: 'foo' | 'bar';
 }`);
@@ -282,18 +290,17 @@ describe('update-scope-schema generator', () => {
 async function addUtilLibProject(tree: Tree) {
   await pluginGenerator(tree, {
     name: 'internal-plugin',
-    directory: 'libs/internal-plugin'
+    directory: 'libs/internal-plugin',
     skipTsConfig: false,
     unitTestRunner: 'jest',
     linter: Linter.EsLint,
     compiler: 'tsc',
     skipFormat: false,
     skipLintChecks: false,
-    minimal: true,
   });
   await generatorGenerator(tree, {
     name: 'util-lib',
-    directory: 'libs/internal-plugin/src/generators/util-lib',
+    path: 'libs/internal-plugin/src/generators/util-lib',
     unitTestRunner: 'jest',
   });
   const filesToCopy = [
@@ -308,6 +315,7 @@ async function addUtilLibProject(tree: Tree) {
     );
   }
 }
+
 ```
 
 </details>

--- a/exercises/advanced/complex-generators.md
+++ b/exercises/advanced/complex-generators.md
@@ -220,6 +220,8 @@ their scope files.
 }
 ```
 
+You may need to install husky with `npm install -D husky`.
+
 </details>
 
 ### 6. `✨ BONUS` Create a unit test to verify functionality

--- a/exercises/advanced/complex-generators.md
+++ b/exercises/advanced/complex-generators.md
@@ -328,4 +328,4 @@ You learned how to generate and test complex generators. In the next step we wil
 
 ⚠️&nbsp;&nbsp;Don't forget to commit everything before you move on.
 
-## [➡️ Next lab ➡️](./deploy-target-and-custom-executor.md)
+## [➡️ Next lab ➡️](./setup-ci-and-connect-nx-cloud.md)

--- a/exercises/advanced/complex-generators.md
+++ b/exercises/advanced/complex-generators.md
@@ -130,7 +130,7 @@ import {
   getProjects,
 } from '@nx/devkit';
 
-export default async function (tree: Tree) {
+export async function generator(tree: Tree) {
   const scopes = getScopes(getProjects(tree));
   updateSchemaJson(tree, scopes);
   updateSchemaInterface(tree, scopes);
@@ -242,7 +242,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import { Linter } from '@nx/eslint';
-import generator from './generator';
+import { generator } from './generator';
 
 describe('update-scope-schema generator', () => {
   let appTree: Tree;

--- a/exercises/advanced/complex-generators.md
+++ b/exercises/advanced/complex-generators.md
@@ -54,7 +54,7 @@ function getScopes(projectMap: Map<string, ProjectConfiguration>) {
   const allScopes: string[] = Array.from(projectMap.values())
     .map((project) => {
       if (project.tags) {
-        const scopes = project.tags.filter((tag: string) => tag.startsWith('scope:'));
+        const scopes = project.tags?.filter((tag: string) => tag.startsWith('scope:')) ?? [];
         return scopes;
       }
       return [];
@@ -141,7 +141,7 @@ function getScopes(projectMap: Map<string, ProjectConfiguration>) {
   const projects: any[] = Array.from(projectMap.values());
   const allScopes: string[] = projects
     .map((project) =>
-      project.tags.filter((tag: string) => tag.startsWith('scope:'))
+      project.tags?.filter((tag: string) => tag.startsWith('scope:')) ?? []
     )
     .reduce((acc, tags) => [...acc, ...tags], [])
     .map((scope: string) => scope.slice(6));

--- a/exercises/advanced/custom-plugins.md
+++ b/exercises/advanced/custom-plugins.md
@@ -108,6 +108,8 @@ asked about which bundler to use when creating libs). The generator should gener
 
 - `movies`-> `libs/movies/{lib name}`
 
+The generator should also add the directory as a prefix to the lib name.
+
 <details>
 <summary>🐳&nbsp;&nbsp;Hint</summary>
 
@@ -136,7 +138,7 @@ locally generated files again.
 Let's add some functionality to the lib you just created:
 
 - Generate a new lib called `util-notifications` in the `api` directory using our new generator
-- In `libs/api/util-notifications/src/lib/util-notifications.ts`
+- In `libs/api/util-notifications/src/lib/api-util-notifications.ts`
 - Add:
   ```typescript
   export function sendNotification(clientId: string) {

--- a/exercises/advanced/custom-plugins.md
+++ b/exercises/advanced/custom-plugins.md
@@ -136,7 +136,7 @@ locally generated files again.
 Let's add some functionality to the lib you just created:
 
 - Generate a new lib called `util-notifications` in the `api` directory using our new generator
-- In `libs/api/util-notifications/src/lib/api-util-notifications.ts`
+- In `libs/api/util-notifications/src/lib/util-notifications.ts`
 - Add:
   ```typescript
   export function sendNotification(clientId: string) {

--- a/exercises/advanced/custom-plugins.md
+++ b/exercises/advanced/custom-plugins.md
@@ -67,7 +67,7 @@ Try to run your generator to see what changes are being made (you can append `--
 
 ### 5. Extend other generators
 
-We can call other generators inside of our custom generator. Import the `@nx/js:library` generator and call it inside of the default exported function of `libs/internal-plugin/src/generators/util-lib/generator.ts`
+We can call other generators inside of our custom generator. Add `@nx/js` as a dependency of `internal-plugin`. Then, import the `@nx/js:library` generator and call it inside of the default exported function of `libs/internal-plugin/src/generators/util-lib/generator.ts`
 
 <details>
 <summary>🐳&nbsp;&nbsp;Hint</summary>

--- a/exercises/advanced/flaky-tasks.md
+++ b/exercises/advanced/flaky-tasks.md
@@ -33,4 +33,4 @@ Also if you open the the project containing the flaky task you should see how it
 
 ## That's it! 🎉
 
-You made it all the way through! Are you up for some [✨ bonus tasks ✨](./infer-target.md)?
+You made it all the way through! Are you up for some [✨ bonus tasks ✨](./bonus.md)?

--- a/exercises/advanced/flaky-tasks.md
+++ b/exercises/advanced/flaky-tasks.md
@@ -25,11 +25,11 @@ Make a couple of arbitrary changes and push them to trigger to a new CI run.
 
 If you succeed you should see a note at the top of the dashboard indicating the presence of some flaky tasks.
 
-![flaky tasks](images/flaky-tasks.png)
+![flaky tasks](../images/flaky-tasks.png)
 
 Also if you open the the project containing the flaky task you should see how it got retried:
 
-![flaky task retry](images/flaky-task-retry.png)
+![flaky task retry](../images/flaky-task-retry.png)
 
 ## That's it! 🎉
 

--- a/exercises/advanced/nx-agents.md
+++ b/exercises/advanced/nx-agents.md
@@ -108,7 +108,7 @@ Inspect the Nx Cloud dashboard. You should see your new launch template being us
 
 ![custom-launch-template](../images/nx-cloud-custom-launch-template.png)
 
-If needed, you can forward environment variables to the Nx Agents by using the `--with-env-vars` flag:
+If needed, you can forward environment variables to the Nx Agents by using the `--with-env-vars` flag on the `start-ci-run` command:
 
 ```bash
  --with-env-vars="MY_SECRET_TOKEN,MY_OTHER_TOKEN"

--- a/exercises/advanced/nx-agents.md
+++ b/exercises/advanced/nx-agents.md
@@ -23,8 +23,6 @@ To enable Nx Agents, let's adjust the CI config. There should be already a comme
 ```
 
 </details>
- 
-Also, for now, uncomment the `deploy` target. We'll come back to it later in this lab.
 
 Now commit the changes and push them to trigger a new CI run.
 
@@ -56,32 +54,9 @@ distribute-on:
 
 </details>
 
-### 3. Create a custom template to install Fly.io
+### 3. `✨ BONUS` Create a custom template to install other dependencies
 
-Re-enable the `deploy` target in your CI config and check the output log. You should probably see an error about not being able to find `fly` in the PATH.
-
-```bash
-/bin/sh: 1: flyctl: not found
-```
-
-This is because the [default Nx Agents templates](https://github.com/nrwl/nx-cloud-workflows/tree/main/launch-templates) do not include the `fly` CLI.
-
-To use the Fly CLI on Nx Agents we need to create a custom launch template. Use the [docs](https://nx.dev/ci/reference/launch-templates) as a reference to create a new template in `.nx/workflows/agents.yaml`.
-
-<details>
-<summary>🐳&nbsp;&nbsp;Hint: Installing Fly.io</summary>
-
-```
-curl -L https://fly.io/install.sh | sh
-```
-
-To add it to the PATH, you can use the following command:
-
-```
-echo PATH="$HOME/.fly/bin:$PATH" >> $NX_CLOUD_ENV
-```
-
-</details>
+To customize the setup steps of Nx Agents, you can create a custom Launch Template. This is useful when you need to install additional dependencies or tools. Use the [docs](https://nx.dev/ci/reference/launch-templates) as a reference to create a new template in `.nx/workflows/agents.yaml`.
 
 <details>
 <summary>🐳&nbsp;&nbsp;Solution (custom launch template)</summary>
@@ -107,14 +82,15 @@ launch-templates:
           paths: |
             '../.cache/Cypress'
           base-branch: 'main'
+      - name: Install Pnpm 9
+        script: |
+          npm install -g pnpm@9 --force
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-browsers/main.yaml'
-      - name: Install Fly.io
-        script: |
-          curl -L https://fly.io/install.sh | sh
-          echo PATH="$HOME/.fly/bin:$PATH" >> $NX_CLOUD_ENV
+      # Install any other dependencies here
+      # After each Nx Agent reaches this point, it will be ready to execute tasks
 ```
 
 </details>
@@ -132,17 +108,10 @@ Inspect the Nx Cloud dashboard. You should see your new launch template being us
 
 ![custom-launch-template](../images/nx-cloud-custom-launch-template.png)
 
-> ⚠️&nbsp;&nbsp;Your Fly.io deployment might still not work. Check the logs on Nx CLoud to see why.
-
-Use the following [docs page](https://nx.dev/ci/reference/launch-templates#pass-environment-variables-to-agents) to fix the issue.
-
-<details>
-<summary>🐳&nbsp;&nbsp;Solution</summary>
-
-You need to forward the environment variables to the Nx Agents by using the `--with-env-vars` flag:
+If needed, you can forward environment variables to the Nx Agents by using the `--with-env-vars` flag:
 
 ```bash
- --with-env-vars="SURGE_DOMAIN_STORE,SURGE_TOKEN,FLY_API_TOKEN"
+ --with-env-vars="MY_SECRET_TOKEN,MY_OTHER_TOKEN"
 ```
 
 </details>

--- a/exercises/advanced/setup-ci-and-connect-nx-cloud.md
+++ b/exercises/advanced/setup-ci-and-connect-nx-cloud.md
@@ -139,6 +139,6 @@ git pull
 
 Now run any test, lint or build command. Notice how it's being retreived from the remote cache.
 
-![nx-cloud-cache](images/nx-cloud-cache.png)
+![nx-cloud-cache](../images/nx-cloud-cache.png)
 
 ## [➡️ Next lab ➡️](./caching-deep-dive.md)


### PR DESCRIPTION
This PR changes a number of items in the workshop:
- Removes the fly.io portion and hides both sections related to app deployment
- Updates some code snippets that were outdated
- Fixes broken links
- Adds clarity to some steps

You can step through the workshop from the updated readme [here](https://github.com/fahslaj/ng-be-workshop-2024/tree/tweaks).